### PR TITLE
Remove unused demo task functions

### DIFF
--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -5,7 +5,6 @@ const path = require('path');
 const extend = require('node.extend');
 const log = require('../helpers/log');
 const files = require('../helpers/files');
-const build = require('../tasks/build');
 const merge = require('merge-stream');
 const through = require('through2');
 const combine = require('stream-combiner2');
@@ -17,63 +16,6 @@ const defaultDemoConfig = {
 	documentClasses: '',
 	description: ''
 };
-
-function buildSass(gulp, buildConfig) {
-	const src = path.join(buildConfig.cwd, '/' + buildConfig.demo.sass);
-	const dest = path.join(buildConfig.cwd, '/demos/');
-	if (builtFiles.css.indexOf(src) === -1) {
-		if (!fs.existsSync(src)) {
-			throw new Error('Sass file not found: ' + src);
-		}
-
-		const bowerConfig = files.getBowerJson();
-		let prefixSass = '';
-		// If module has o-assets as a dependency, set local demos to use local assets
-		// to use the latest ones in the repo
-		if (bowerConfig && bowerConfig.dependencies && bowerConfig.dependencies['o-assets']) {
-			const moduleName = bowerConfig.name;
-			prefixSass = '@import \'o-assets/main\';\n' +
-				'@include oAssetsSetModulePaths((' + moduleName + ': ""));\n';
-		}
-
-		builtFiles.css.push(src);
-
-		const sassConfig = {
-			sass: src,
-			sassPrefix: prefixSass,
-			// For the Sass files to load correctly, they need to be in one of these two directories.
-			// Sass doesn't look in subdirectories and we can't use wildcards
-			sassIncludePaths: ['demos/src', 'demos/src/scss'],
-			sourcemaps: true,
-			buildCss: path.basename(buildConfig.demo.sass).replace('.scss', '.css'),
-			buildFolder: dest
-		};
-
-		return build.sass(gulp, sassConfig);
-	}
-}
-
-function buildJs(gulp, buildConfig) {
-	const src = path.join(buildConfig.cwd, '/' + buildConfig.demo.js);
-	const destFolder = path.join(buildConfig.cwd, '/demos/');
-	const dest = path.basename(buildConfig.demo.js);
-	if (builtFiles.js.indexOf(src) === -1) {
-		if (!fs.existsSync(src)) {
-			throw new Error('JavaScript file not found: ' + src);
-		}
-
-		builtFiles.js.push(src);
-
-		const jsConfig = {
-			js: src,
-			buildFolder: destFolder,
-			buildJs: dest,
-			sourcemaps: true
-		};
-
-		return build.js(gulp, jsConfig);
-	}
-}
 
 function buildHtml(gulp, buildConfig) {
 	const src = path.join(buildConfig.cwd, '/' + buildConfig.demo.template);


### PR DESCRIPTION
Origami Build Service uses the demo command to build templates only.
It does not use the demo command to build demo JS and Sass assets.

Relates to this commit:
https://github.com/Financial-Times/obt5fork/commit/e2b0695ba8c593dc766607efcbb7689d8ee6468a