### PR TITLE
Remove task loader

### DIFF
--- a/lib/origami-build-tools.js
+++ b/lib/origami-build-tools.js
@@ -1,6 +1,8 @@
 'use strict';
 
 require('isomorphic-fetch');
+const build = require('./tasks/build');
+const demo = require('./tasks/demo');
 
 const metrics = require('./helpers/metrics');
 const nodeVersion = process.version.slice(1).split('.')[0];
@@ -13,54 +15,9 @@ data.nodeVersion.invoked[nodeVersion] = 1;
 metrics(data);
 
 const update = require('./helpers/update-notifier');
-const log = require('./helpers/log');
 update();
 
-function TaskLoader() {
-	this.tasks = {
-		'build': './tasks/build',
-		'demo': './tasks/demo'
-	};
-
-	this.taskCache = {};
-
-	// Allow access of each task via a property of the TaskLoader
-	Object.keys(this.tasks).forEach(function(task) {
-		Object.defineProperty(TaskLoader.prototype, task, {
-			get: function() {
-				return this.load(task);
-			}
-		});
-	});
-}
-
-TaskLoader.prototype.load = function(taskName) {
-	if (this.taskCache.hasOwnProperty(taskName)) {
-		return this.taskCache[taskName];
-	}
-
-	const startTime = process.hrtime();
-	const module = require(this.tasks[taskName]);
-	const timeTaken = process.hrtime(startTime);
-	log.debug('Loaded task: ' + taskName + ' in ' + timeTaken.join('.') + 's');
-	this.taskCache[taskName] = module;
-	return module;
+module.exports = {
+	'build': build,
+	'demo': demo
 };
-
-TaskLoader.prototype.isValid = function(taskName) {
-	return this.tasks.hasOwnProperty(taskName);
-};
-
-TaskLoader.prototype.list = function() {
-	return Object.keys(this.tasks);
-};
-
-TaskLoader.prototype.loadAll = function() {
-	const loader = this;
-	return this.list().reduce(function(modules, task) {
-		modules[task] = loader.load(task);
-		return modules;
-	}, {});
-};
-
-module.exports = new TaskLoader();

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const merge = require('merge-stream');
 const BowerResolvePlugin = require('bower-resolve-webpack-plugin');
 const webpack = require('webpack');
 const webpackStream = require('webpack-stream');


### PR DESCRIPTION
origami-build-service uses both remaining tasks. I don't think
there is a benefit to keeping the task loader.