### PR TITLE
Remove the build destination file helper

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -3,11 +3,6 @@
 const fs = require('fs');
 const path = require('path');
 
-function getBuildFolderPath(cwd) {
-	cwd = cwd || process.cwd();
-	return path.join(cwd, '/build/');
-}
-
 function requireIfExists(filePath) {
 	if (fs.existsSync(filePath)) {
 		return require(filePath);
@@ -102,7 +97,6 @@ function getMustacheFilesList(basePath) {
 	return mustacheFiles.sort();
 }
 
-exports.getBuildFolderPath = getBuildFolderPath;
 exports.getMainSassPath = getMainSassPath;
 exports.getMainJsPath = getMainJsPath;
 exports.getModuleName = getModuleName;

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -69,7 +69,7 @@ module.exports.js = function(gulp, config) {
 
 		const useSourceMaps = config.sourcemaps || (config.env === 'development');
 
-		const destFolder = config.buildFolder || files.getBuildFolderPath();
+		const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
 		const dest = config.buildJs || 'main.js';
 
 
@@ -172,7 +172,7 @@ module.exports.sass = function(gulp, config) {
 	const cwd = config.cwd || process.cwd();
 
 	if (src) {
-		const destFolder = config.buildFolder || files.getBuildFolderPath();
+		const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
 		const dest = config.buildCss || 'main.css';
 
 		console.log('Compiling ' + src);

--- a/test/helpers/files.test.js
+++ b/test/helpers/files.test.js
@@ -24,10 +24,6 @@ describe('Files helper', function() {
 		fs.removeSync(filesTestPath);
 	});
 
-	it('should return correct build folder', function() {
-		expect(files.getBuildFolderPath()).to.be(process.cwd() + '/build/');
-	});
-
 	it('should return module name', function() {
 		expect(files.getModuleName()).to.be('');
 		fs.writeFileSync('bower.json', JSON.stringify({ name: 'o-test' }), 'utf8');


### PR DESCRIPTION
The origami build service sets `config.buildFolder`, the fallbacks
can be removed when we move this into the build service codebase