### PR TITLE
Remove defaults for `js`, `sass`, `cwd`, `buildFolder` build options.

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -16,56 +16,6 @@ function getBowerJson(cwd) {
 	return requireIfExists(path.join(cwd, '/bower.json'));
 }
 
-function getMainSassPath(cwd) {
-	cwd = cwd || process.cwd();
-	const sassMainPath = path.join(cwd, '/main.scss');
-	const bowerJson = getBowerJson(cwd);
-	const fileExists = fs.existsSync(sassMainPath);
-	let isInBowerMain = false;
-	if (bowerJson) {
-		if (bowerJson.main instanceof Array && bowerJson.main.indexOf('main.scss') > -1) {
-			isInBowerMain = true;
-		} else if (typeof bowerJson.main === 'string' && bowerJson.main === 'main.scss') {
-			isInBowerMain = true;
-		}
-	}
-	if (isInBowerMain && !fileExists) {
-		console.log('main.scss is listed in bower.json main, but file doesn\'t exist.');
-	} else if (!isInBowerMain && fileExists) {
-		console.log('main.scss exists but is not listed in bower.json main.');
-	}
-	if (isInBowerMain && fileExists) {
-		return sassMainPath;
-	} else {
-		return null;
-	}
-}
-
-function getMainJsPath(cwd) {
-	cwd = cwd || process.cwd();
-	const jsMainPath = path.join(cwd, '/main.js');
-	const bowerJson = getBowerJson(cwd);
-	const fileExists = fs.existsSync(jsMainPath);
-	let isInBowerMain = false;
-	if (bowerJson) {
-		if (bowerJson.main instanceof Array && bowerJson.main.indexOf('main.js') > -1) {
-			isInBowerMain = true;
-		} else if (typeof bowerJson.main === 'string' && bowerJson.main === 'main.js') {
-			isInBowerMain = true;
-		}
-	}
-	if (isInBowerMain && !fileExists) {
-		console.log('main.js is listed in bower.json main, but file doesn\'t exist.');
-	} else if (!isInBowerMain && fileExists) {
-		console.log('main.js exists but is not listed in bower.json main.');
-	}
-	if (isInBowerMain && fileExists) {
-		return jsMainPath;
-	} else {
-		return null;
-	}
-}
-
 function getModuleName(cwd) {
 	const bowerJson = getBowerJson(cwd);
 	if (bowerJson) {
@@ -97,7 +47,5 @@ function getMustacheFilesList(basePath) {
 	return mustacheFiles.sort();
 }
 
-exports.getMainSassPath = getMainSassPath;
-exports.getMainJsPath = getMainJsPath;
 exports.getModuleName = getModuleName;
 exports.getMustacheFilesList = getMustacheFilesList;

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -12,221 +12,242 @@ const rename = require('gulp-rename');
 const gulpif = require('gulp-if-else');
 const autoprefixer = require('gulp-autoprefixer');
 const prefixer = require('../plugins/gulp-prefixer');
-const files = require('../helpers/files');
 
 module.exports.js = function(gulp, config) {
 	config = config || {};
-	const src = config.js || files.getMainJsPath() || null;
-	const cwd = config.cwd || process.cwd();
+
+	if (!config.js) {
+		return;
+	}
+
+	if (!config.cwd) {
+		throw new Error(`Could not build JavaScript. Missing configuration: "cwd".`);
+	}
+
+	if (!config.buildFolder) {
+		throw new Error(`Could not build JavaScript. Missing configuration: "buildFolder".`);
+	}
+
+	const src = config.js;
+	const cwd = config.cwd;
 	const babelRuntime = typeof config.babelRuntime === 'undefined' ? true : config.babelRuntime;
 
-	if (src) {
-		// Temporary fix as aliased loaders don't pass in queries due to webpack bug
-		const textrequireifyPath = path.join(__dirname, '../plugins/textrequireify-loader.js');
+	// Temporary fix as aliased loaders don't pass in queries due to webpack bug
+	const textrequireifyPath = path.join(__dirname, '../plugins/textrequireify-loader.js');
 
-		const babelPlugins = [
-			require.resolve('babel-plugin-add-module-exports')
-		];
+	const babelPlugins = [
+		require.resolve('babel-plugin-add-module-exports')
+	];
 
-		if (babelRuntime) {
-			// Polyfills the runtime needed for async/await and generators
-			// Useful for applications rather than components.
-			babelPlugins.push(require.resolve('babel-plugin-transform-runtime'));
-		}
-
-		// They're loaded right to left
-		const loaders = [
-			{
-				loader: textrequireifyPath,
-				options: {
-					cwd: cwd
-				}
-			},
-			// Makes paths to babel-runtime polyfills absolute as they're
-			// in OBT's node_modules directory and not the module's
-			{
-				loader: 'babel-runtime-path-loader',
-			},
-			{
-				loader: 'babel-loader',
-				options: {
-					// TODO: Look into using preset-env instead and specifying our minimum versions
-					// for enhanced experience instead of making everything become ES5
-					presets: [
-						require.resolve('babel-preset-es3'),
-						require.resolve('babel-preset-es2015'),
-						require.resolve('babel-preset-es2016'),
-						require.resolve('babel-preset-es2017')
-					],
-					plugins: babelPlugins
-				}
-			},
-			// Disables AMD module loading
-			'imports-loader?define=>false'
-		];
-
-		config.env = config.env || 'development';
-
-		const useSourceMaps = config.sourcemaps || (config.env === 'development');
-
-		const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
-		const dest = config.buildJs || 'main.js';
-
-
-		console.log('Webpacking ' + src);
-
-		const plugins = [new webpack.LoaderOptionsPlugin({
-			options: {
-				quiet: true
-			}
-		})];
-
-		if (config.env === 'production') {
-			plugins.push(new webpack.optimize.UglifyJsPlugin({
-				sourceMap: useSourceMaps
-			}));
-			plugins.push(new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }));
-		}
-		const webpackConfig = {
-			resolve: {
-				// This will handle a bower.json's `main` property being an array.
-				plugins: [new BowerResolvePlugin()],
-				// In which folders the resolver look for modules
-				// relative paths are looked up in every parent folder (like node_modules)
-				// absolute paths are looked up directly
-				// the order is respected
-				modules: ['bower_components', 'node_modules'],
-				// These JSON files are read in directories
-				descriptionFiles: ['bower.json', 'package.json'],
-				// These fields in the description files are looked up when trying to resolve the package directory
-				mainFields: ['browser', 'main'],
-				// These files are tried when trying to resolve a directory
-				mainFiles: ['index', 'main'],
-				// These extensions are tried when resolving a file
-				extensions: ['.js', '.json']
-			},
-			resolveLoader: {
-				modules: [
-					path.join(__dirname, '../../node_modules'),
-					path.join(process.cwd(), './node_modules')
-				],
-				alias: {
-					'babel-runtime-path-loader': path.join(__dirname, '../plugins/babelRuntimePathResolver'),
-					'textrequireify-loader': path.join(__dirname, '../plugins/textrequireify-loader')
-				}
-			},
-			plugins: plugins,
-			module: {
-				rules: [
-					{
-						test: /\.js$/,
-						exclude: /node_modules/,
-						use: loaders
-					},
-					// Node.JS, require.js and Browserify support requiring JSON files
-					// json-loader does this in webpack
-					{
-						test: /\.json$/,
-						loader: 'json-loader'
-					},
-					{
-						test: /\.html$/,
-						loader: 'raw-loader'
-					},
-					{
-						test: /\.txt$/,
-						loader: 'raw-loader'
-					}
-				]
-			},
-			devtool: useSourceMaps ? (useSourceMaps === 'inline' ? 'inline-source-map' : 'source-map') : undefined,
-			output: {
-				devtoolModuleFilenameTemplate: '[resource-path]',
-				filename: dest,
-				sourceMapFilename: dest + '.map'
-			}
-		};
-
-		const combinedStream = combine.obj(
-			gulp.src(src),
-			webpackStream(webpackConfig, webpack),
-			gulpif(destFolder !== 'disabled', function() {
-				return gulp.dest(destFolder);
-			})
-		);
-
-		// Returns a combined stream so an error handler can be attached to the end of the pipeline,
-		// and it will have effects in all the steps. We need to resume() because stream-combiner2
-		// seems to pause the stream and it doesn't reach the `end` event
-		return combinedStream.resume();
+	if (babelRuntime) {
+		// Polyfills the runtime needed for async/await and generators
+		// Useful for applications rather than components.
+		babelPlugins.push(require.resolve('babel-plugin-transform-runtime'));
 	}
+
+	// They're loaded right to left
+	const loaders = [
+		{
+			loader: textrequireifyPath,
+			options: {
+				cwd: cwd
+			}
+		},
+		// Makes paths to babel-runtime polyfills absolute as they're
+		// in OBT's node_modules directory and not the module's
+		{
+			loader: 'babel-runtime-path-loader',
+		},
+		{
+			loader: 'babel-loader',
+			options: {
+				// TODO: Look into using preset-env instead and specifying our minimum versions
+				// for enhanced experience instead of making everything become ES5
+				presets: [
+					require.resolve('babel-preset-es3'),
+					require.resolve('babel-preset-es2015'),
+					require.resolve('babel-preset-es2016'),
+					require.resolve('babel-preset-es2017')
+				],
+				plugins: babelPlugins
+			}
+		},
+		// Disables AMD module loading
+		'imports-loader?define=>false'
+	];
+
+	config.env = config.env || 'development';
+
+	const useSourceMaps = config.sourcemaps || (config.env === 'development');
+
+	const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
+	const dest = config.buildJs || 'main.js';
+
+
+	console.log('Webpacking ' + src);
+
+	const plugins = [new webpack.LoaderOptionsPlugin({
+		options: {
+			quiet: true
+		}
+	})];
+
+	if (config.env === 'production') {
+		plugins.push(new webpack.optimize.UglifyJsPlugin({
+			sourceMap: useSourceMaps
+		}));
+		plugins.push(new webpack.DefinePlugin({ 'process.env': { 'NODE_ENV': '"production"' } }));
+	}
+	const webpackConfig = {
+		resolve: {
+			// This will handle a bower.json's `main` property being an array.
+			plugins: [new BowerResolvePlugin()],
+			// In which folders the resolver look for modules
+			// relative paths are looked up in every parent folder (like node_modules)
+			// absolute paths are looked up directly
+			// the order is respected
+			modules: ['bower_components', 'node_modules'],
+			// These JSON files are read in directories
+			descriptionFiles: ['bower.json', 'package.json'],
+			// These fields in the description files are looked up when trying to resolve the package directory
+			mainFields: ['browser', 'main'],
+			// These files are tried when trying to resolve a directory
+			mainFiles: ['index', 'main'],
+			// These extensions are tried when resolving a file
+			extensions: ['.js', '.json']
+		},
+		resolveLoader: {
+			modules: [
+				path.join(__dirname, '../../node_modules'),
+				path.join(process.cwd(), './node_modules')
+			],
+			alias: {
+				'babel-runtime-path-loader': path.join(__dirname, '../plugins/babelRuntimePathResolver'),
+				'textrequireify-loader': path.join(__dirname, '../plugins/textrequireify-loader')
+			}
+		},
+		plugins: plugins,
+		module: {
+			rules: [
+				{
+					test: /\.js$/,
+					exclude: /node_modules/,
+					use: loaders
+				},
+				// Node.JS, require.js and Browserify support requiring JSON files
+				// json-loader does this in webpack
+				{
+					test: /\.json$/,
+					loader: 'json-loader'
+				},
+				{
+					test: /\.html$/,
+					loader: 'raw-loader'
+				},
+				{
+					test: /\.txt$/,
+					loader: 'raw-loader'
+				}
+			]
+		},
+		devtool: useSourceMaps ? (useSourceMaps === 'inline' ? 'inline-source-map' : 'source-map') : undefined,
+		output: {
+			devtoolModuleFilenameTemplate: '[resource-path]',
+			filename: dest,
+			sourceMapFilename: dest + '.map'
+		}
+	};
+
+	const combinedStream = combine.obj(
+		gulp.src(src),
+		webpackStream(webpackConfig, webpack),
+		gulpif(destFolder !== 'disabled', function() {
+			return gulp.dest(destFolder);
+		})
+	);
+
+	// Returns a combined stream so an error handler can be attached to the end of the pipeline,
+	// and it will have effects in all the steps. We need to resume() because stream-combiner2
+	// seems to pause the stream and it doesn't reach the `end` event
+	return combinedStream.resume();
 };
 
 module.exports.sass = function(gulp, config) {
 	config = config || {};
-	const src = config.sass || files.getMainSassPath() || null;
-	const cwd = config.cwd || process.cwd();
 
-	if (src) {
-		const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
-		const dest = config.buildCss || 'main.css';
-
-		console.log('Compiling ' + src);
-
-		config.env = config.env || 'development';
-		const useSourceMaps = config.sourcemaps || (config.env === 'development');
-
-		const sassConfig = {
-			includePaths: [path.join(cwd, 'bower_components')],
-			outputStyle: 'nested'
-		};
-
-		const autoprefixerConfig = {
-			browsers: ['> 1%', 'last 2 versions', 'ie > 6', 'ff ESR', 'bb >= 7', 'safari >= 8'],
-			cascade: config.autoprefixerCascade || false,
-			flexbox: 'no-2009',
-			remove: config.autoprefixerRemove === undefined ? true : config.autoprefixerRemove
-		};
-
-		const combinedStream = combine.obj(
-			gulp.src(src),
-			gulpif(config.sassPrefix, function() {
-				return prefixer(config.sassPrefix);
-			}),
-			gulpif(useSourceMaps, function() {
-				return sourcemaps.init();
-			}),
-			sass(sassConfig),
-			autoprefixer(autoprefixerConfig),
-			gulpif(config.env === 'production', function() {
-				return cleanCss({
-					advanced: false,
-					compatibility: 'ie8'
-				});
-			}),
-			gulpif(useSourceMaps, function() {
-				if (useSourceMaps === 'inline') {
-					return sourcemaps.write();
-				} else {
-					return sourcemaps.write('./', { sourceMappingURL: () => `${dest}.map` });
-				}
-			}),
-			rename(path => {
-				if (path.extname !== '.map') {
-					path.extname = '';
-				}
-				path.basename = dest;
-			}),
-			gulpif(destFolder !== 'disabled', function() {
-				return gulp.dest(destFolder);
-			})
-		);
-
-		// Returns a combined stream so an error handler can be attached to the end of the pipeline,
-		// and it will have effects in all the steps. We need to resume() because stream-combiner2
-		// seems to pause the stream and it doesn't reach the `end` event
-		return combinedStream.resume();
+	if (!config.sass) {
+		return;
 	}
+
+	if (!config.cwd) {
+		throw new Error(`Could not build JavaScript. Missing configuration: "cwd".`);
+	}
+
+	if (!config.buildFolder) {
+		throw new Error(`Could not build JavaScript. Missing configuration: "buildFolder".`);
+	}
+
+	const src = config.sass;
+	const cwd = config.cwd;
+
+	const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
+	const dest = config.buildCss || 'main.css';
+
+	console.log('Compiling ' + src);
+
+	config.env = config.env || 'development';
+	const useSourceMaps = config.sourcemaps || (config.env === 'development');
+
+	const sassConfig = {
+		includePaths: [path.join(cwd, 'bower_components')],
+		outputStyle: 'nested'
+	};
+
+	const autoprefixerConfig = {
+		browsers: ['> 1%', 'last 2 versions', 'ie > 6', 'ff ESR', 'bb >= 7', 'safari >= 8'],
+		cascade: config.autoprefixerCascade || false,
+		flexbox: 'no-2009',
+		remove: config.autoprefixerRemove === undefined ? true : config.autoprefixerRemove
+	};
+
+	const combinedStream = combine.obj(
+		gulp.src(src),
+		gulpif(config.sassPrefix, function() {
+			return prefixer(config.sassPrefix);
+		}),
+		gulpif(useSourceMaps, function() {
+			return sourcemaps.init();
+		}),
+		sass(sassConfig),
+		autoprefixer(autoprefixerConfig),
+		gulpif(config.env === 'production', function() {
+			return cleanCss({
+				advanced: false,
+				compatibility: 'ie8'
+			});
+		}),
+		gulpif(useSourceMaps, function() {
+			if (useSourceMaps === 'inline') {
+				return sourcemaps.write();
+			} else {
+				return sourcemaps.write('./', { sourceMappingURL: () => `${dest}.map` });
+			}
+		}),
+		rename(path => {
+			if (path.extname !== '.map') {
+				path.extname = '';
+			}
+			path.basename = dest;
+		}),
+		gulpif(destFolder !== 'disabled', function() {
+			return gulp.dest(destFolder);
+		})
+	);
+
+	// Returns a combined stream so an error handler can be attached to the end of the pipeline,
+	// and it will have effects in all the steps. We need to resume() because stream-combiner2
+	// seems to pause the stream and it doesn't reach the `end` event
+	return combinedStream.resume();
 };
 
 module.exports.description = 'Build module in current directory';

--- a/test/helpers/files.test.js
+++ b/test/helpers/files.test.js
@@ -29,34 +29,6 @@ describe('Files helper', function() {
 		fs.unlink(path.resolve(filesTestPath, 'bower.json'));
 	});
 
-	describe('Main files', function() {
-		before(function() {
-			fs.writeFileSync('bower.json', JSON.stringify({ name: 'o-test' }), 'utf8');
-		});
-
-		after(function() {
-			fs.unlink(path.resolve(filesTestPath, 'bower.json'));
-		});
-
-		it('should get the path of main.scss', function() {
-			proclaim.equal(files.getMainSassPath(), null);
-			const bowerJson = require(path.join(process.cwd(), '/bower.json'));
-			bowerJson.main = bowerJson.main || [];
-			bowerJson.main.push('main.scss');
-			fs.writeFileSync('bower.json', JSON.stringify(bowerJson), 'utf8');
-			proclaim.equal(files.getMainSassPath(), process.cwd() + '/main.scss');
-		});
-
-		it('should get the path of main.js', function() {
-			proclaim.equal(files.getMainJsPath(), null);
-			const bowerJson = require(path.join(process.cwd(), '/bower.json'));
-			bowerJson.main = bowerJson.main || [];
-			bowerJson.main.push('main.js');
-			fs.writeFileSync('bower.json', JSON.stringify(bowerJson), 'utf8');
-			proclaim.equal(files.getMainJsPath(), process.cwd() + '/main.js');
-		});
-	});
-
 	describe('.getMustacheFilesList(basePath)', () => {
 		const mustacheTestPath = path.resolve(filesTestPath, 'demos/src');
 		const flatMustacheFiles = path.resolve(mustacheTestPath, 'flat');

--- a/test/tasks/build.test.js
+++ b/test/tasks/build.test.js
@@ -18,9 +18,11 @@ const oTestPath = 'test/fixtures/o-test';
 const CORE_JS_IDENTIFIER = '__core-js_shared__';
 
 describe('Build task', function() {
-	describe('Build Js', function() {
+
+	describe('Build Js', function () {
 		const pathSuffix = '-build-js';
 		const buildTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
+		let defaultOptions;
 
 		before(function() {
 			fs.copySync(path.resolve(obtPath, oTestPath), buildTestPath);
@@ -31,6 +33,11 @@ describe('Build task', function() {
 					main: 'main.js'
 				}
 			), 'utf8');
+			defaultOptions = {
+				cwd: process.cwd(),
+				buildFolder: path.join(process.cwd(), '/build/'),
+				js: path.join(process.cwd(), '/main.js'),
+			};
 		});
 
 		after(function() {
@@ -45,7 +52,7 @@ describe('Build task', function() {
 		});
 
 		it('should work with default options', function(done) {
-			build.js(gulp)
+			build.js(gulp, defaultOptions)
 				.on('end', function() {
 					const builtJs = fs.readFileSync('build/main.js', 'utf8');
 					proclaim.include(builtJs, 'sourceMappingURL');
@@ -59,9 +66,9 @@ describe('Build task', function() {
 
 		it('should work with production option', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, defaultOptions, {
 					env: 'production'
-				})
+				}))
 				.on('end', function() {
 					const builtJs = fs.readFileSync('build/main.js', 'utf8');
 					proclaim.doesNotInclude(builtJs, 'sourceMappingURL');
@@ -75,9 +82,9 @@ describe('Build task', function() {
 
 		it('should include the the babel-runtime polyfills by default', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, defaultOptions, {
 					js: './src/js/babelRuntime.js'
-				})
+				}))
 				.on('end', function() {
 					const builtJs = fs.readFileSync('build/main.js', 'utf8');
 					proclaim.include(builtJs, CORE_JS_IDENTIFIER);
@@ -87,10 +94,10 @@ describe('Build task', function() {
 
 		it('should not include the the babel-runtime polyfills if \'babelRuntime\' is falsey', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, {
 					js: './src/js/babelRuntime.js',
 					babelRuntime: false
-				})
+				}, defaultOptions))
 				.on('end', function() {
 					const builtJs = fs.readFileSync('build/main.js', 'utf8');
 					proclaim.doesNotInclude(builtJs, CORE_JS_IDENTIFIER);
@@ -100,9 +107,9 @@ describe('Build task', function() {
 
 		it('should build from custom source', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, defaultOptions, {
 					js: './src/js/test.js'
-				})
+				}))
 				.on('end', function() {
 					const builtJs = fs.readFileSync('build/main.js', 'utf8');
 					proclaim.include(builtJs, 'sourceMappingURL');
@@ -114,9 +121,9 @@ describe('Build task', function() {
 
 		it('should build to a custom directory', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, defaultOptions, {
 					buildFolder: 'test-build'
-				})
+				}))
 				.on('end', function() {
 					const builtJs = fs.readFileSync('test-build/main.js', 'utf8');
 					proclaim.include(builtJs, 'sourceMappingURL');
@@ -130,9 +137,9 @@ describe('Build task', function() {
 
 		it('should build to a custom file', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, defaultOptions, {
 					buildJs: 'bundle.js'
-				})
+				}))
 				.on('end', function() {
 					const builtJs = fs.readFileSync('build/bundle.js', 'utf8');
 					proclaim.include(builtJs, 'sourceMappingURL');
@@ -146,9 +153,9 @@ describe('Build task', function() {
 
 		it('should fail on syntax error', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, defaultOptions, {
 					js: './src/js/syntax-error.js'
-				})
+				}))
 				.on('error', function(e) {
 					proclaim.include(e.message, 'SyntaxError');
 					proclaim.include(e.message, 'Unexpected token');
@@ -163,9 +170,9 @@ describe('Build task', function() {
 
 		it('should fail when a dependency is not found', function(done) {
 			build
-				.js(gulp, {
+				.js(gulp, Object.assign({}, defaultOptions, {
 					js: './src/js/missing-dep.js'
-				})
+				}))
 				.on('error', function(e) {
 					try {
 						proclaim.include(e.message, 'Module not found: Error: Can\'t resolve \'dep\'');
@@ -183,6 +190,7 @@ describe('Build task', function() {
 	describe('Build Sass', function() {
 		const pathSuffix = '-build-sass';
 		const buildTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
+		let defaultOptions;
 
 		before(function() {
 			fs.copySync(path.resolve(obtPath, oTestPath), buildTestPath);
@@ -193,6 +201,11 @@ describe('Build task', function() {
 					main: 'main.scss'
 				}
 			), 'utf8');
+			defaultOptions = {
+				cwd: process.cwd(),
+				buildFolder: path.join(process.cwd(), '/build/'),
+				sass: path.join(process.cwd(), '/main.scss'),
+			};
 		});
 
 		after(function() {
@@ -205,7 +218,7 @@ describe('Build task', function() {
 		});
 
 		it('should work with default options', function(done) {
-			build.sass(gulp)
+			build.sass(gulp, defaultOptions)
 				.on('end', function() {
 					const builtCss = fs.readFileSync('build/main.css', 'utf8');
 					proclaim.include(builtCss, 'div {\n  color: blue; }\n');
@@ -215,9 +228,9 @@ describe('Build task', function() {
 
 		it('should work with production option', function(done) {
 			build
-				.sass(gulp, {
+				.sass(gulp, Object.assign({}, defaultOptions, {
 					env: 'production'
-				})
+				}))
 				.on('end', function() {
 					const builtCss = fs.readFileSync('build/main.css', 'utf8');
 					proclaim.equal(builtCss, 'div{color:#00f}');
@@ -227,9 +240,9 @@ describe('Build task', function() {
 
 		it('should build from custom source', function(done) {
 			build
-				.sass(gulp, {
+				.sass(gulp, Object.assign({}, defaultOptions, {
 					sass: './src/scss/test.scss'
-				})
+				}))
 				.on('end', function() {
 					const builtCss = fs.readFileSync('build/main.css', 'utf8');
 					proclaim.include(builtCss, 'p {\n  color: #000000; }\n');
@@ -239,9 +252,9 @@ describe('Build task', function() {
 
 		it('should build to a custom directory', function(done) {
 			build
-				.sass(gulp, {
+				.sass(gulp, Object.assign({}, defaultOptions, {
 					buildFolder: 'test-build'
-				})
+				}))
 				.on('end', function() {
 					const builtCss = fs.readFileSync('test-build/main.css', 'utf8');
 					proclaim.include(builtCss, 'div {\n  color: blue; }\n');
@@ -252,9 +265,9 @@ describe('Build task', function() {
 
 		it('should build to a custom file', function(done) {
 			build
-				.sass(gulp, {
+				.sass(gulp, Object.assign({}, defaultOptions, {
 					buildCss: 'bundle.css'
-				})
+				}))
 				.on('end', function() {
 					const builtCss = fs.readFileSync('build/bundle.css', 'utf8');
 					proclaim.include(builtCss, 'div {\n  color: blue; }\n');


### PR DESCRIPTION
origami build service does not execute the cli so any option which
falls back to `process.cwd` is not useful.

Review with [whitespace ignored](https://github.com/Financial-Times/obt5fork/pull/58/files?diff=split&w=1)