### PR TITLE
Require `js` and `sass` build options

### DIFF
--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -16,16 +16,17 @@ const prefixer = require('../plugins/gulp-prefixer');
 module.exports.js = function(gulp, config) {
 	config = config || {};
 
+	const configErrorPrefix = 'Could not build JavaScript. Missing configuration for the ';
 	if (!config.js) {
-		return;
+		throw new Error(`${configErrorPrefix} main path to build: "js".`);
 	}
 
 	if (!config.cwd) {
-		throw new Error(`Could not build JavaScript. Missing configuration: "cwd".`);
+		throw new Error(`${configErrorPrefix} component directory: "cwd".`);
 	}
 
 	if (!config.buildFolder) {
-		throw new Error(`Could not build JavaScript. Missing configuration: "buildFolder".`);
+		throw new Error(`${configErrorPrefix} build output directory: "buildFolder".`);
 	}
 
 	const src = config.js;
@@ -175,16 +176,17 @@ module.exports.js = function(gulp, config) {
 module.exports.sass = function(gulp, config) {
 	config = config || {};
 
+	const configErrorPrefix = 'Could not build Sass. Missing configuration for the ';
 	if (!config.sass) {
-		return;
+		throw new Error(`${configErrorPrefix} main path to build: "sass".`);
 	}
 
 	if (!config.cwd) {
-		throw new Error(`Could not build JavaScript. Missing configuration: "cwd".`);
+		throw new Error(`${configErrorPrefix} component directory: "cwd".`);
 	}
 
 	if (!config.buildFolder) {
-		throw new Error(`Could not build JavaScript. Missing configuration: "buildFolder".`);
+		throw new Error(`${configErrorPrefix} build output directory: "buildFolder".`);
 	}
 
 	const src = config.sass;


### PR DESCRIPTION
The origami build service assumes a Stream is returned, and would
error if an `undefined` value is returned, so we can safely error
if a falsy value is given.