### PR TITLE
Remove remaining options which use `process.cwd`.

### DIFF
--- a/lib/helpers/files.js
+++ b/lib/helpers/files.js
@@ -11,13 +11,12 @@ function requireIfExists(filePath) {
 	}
 }
 
-function getBowerJson(cwd) {
-	cwd = cwd || process.cwd();
-	return requireIfExists(path.join(cwd, '/bower.json'));
-}
-
 function getModuleName(cwd) {
-	const bowerJson = getBowerJson(cwd);
+	if (!cwd) {
+		throw new Error('Could not get component name. No directory for the component was given.');
+	}
+	const bowerPath = path.join(cwd, '/bower.json');
+	const bowerJson = requireIfExists(bowerPath);
 	if (bowerJson) {
 		return bowerJson.name;
 	}

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -81,7 +81,7 @@ module.exports.js = function(gulp, config) {
 
 	const useSourceMaps = config.sourcemaps || (config.env === 'development');
 
-	const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
+	const destFolder = config.buildFolder;
 	const dest = config.buildJs || 'main.js';
 
 
@@ -192,7 +192,7 @@ module.exports.sass = function(gulp, config) {
 	const src = config.sass;
 	const cwd = config.cwd;
 
-	const destFolder = config.buildFolder || path.join(process.cwd(), '/build/');
+	const destFolder = config.buildFolder;
 	const dest = config.buildCss || 'main.css';
 
 	console.log('Compiling ' + src);

--- a/lib/tasks/demo.js
+++ b/lib/tasks/demo.js
@@ -171,7 +171,10 @@ function errorStream(stream, errorMessage) {
 module.exports = function(gulp, config) {
 	config = config || {};
 
-	const cwd = config.cwd || process.cwd();
+	const cwd = config.cwd;
+	if (!config.cwd) {
+		throw new Error('Could not build demo templates. Missing configuration for the component directory: "cwd".');
+	}
 
 	// We also support the legacy config.json and config.js so the build service
 	// can keep on compiling demos of older versions of modules

--- a/test/helpers/files.test.js
+++ b/test/helpers/files.test.js
@@ -6,27 +6,29 @@ const proclaim = require('proclaim');
 
 const files = require('../../lib/helpers/files');
 
-const obtPath = process.cwd();
+const obtPath = path.resolve(__dirname, '../../');
 const oTestPath = 'test/fixtures/o-test';
 const pathSuffix = '-file';
 const filesTestPath = path.resolve(obtPath, oTestPath + pathSuffix);
 
 describe('Files helper', function() {
-	before(function() {
+	beforeEach(function() {
 		fs.copySync(path.resolve(obtPath, oTestPath), filesTestPath);
 		process.chdir(filesTestPath);
 	});
 
-	after(function() {
+	afterEach(function() {
 		process.chdir(obtPath);
 		fs.removeSync(filesTestPath);
 	});
 
-	it('should return module name', function() {
-		proclaim.equal(files.getModuleName(), '');
+	it('should return an empty string give no bower.json', function () {
+		proclaim.equal(files.getModuleName(filesTestPath), '');
+	});
+
+	it('should return module name given a bower.json with a name property', function() {
 		fs.writeFileSync('bower.json', JSON.stringify({ name: 'o-test' }), 'utf8');
-		proclaim.equal(files.getModuleName(), 'o-test');
-		fs.unlink(path.resolve(filesTestPath, 'bower.json'));
+		proclaim.equal(files.getModuleName(filesTestPath), 'o-test');
 	});
 
 	describe('.getMustacheFilesList(basePath)', () => {

--- a/test/tasks/build.test.js
+++ b/test/tasks/build.test.js
@@ -12,7 +12,7 @@ const path = require('path');
 
 const build = require('../../lib/tasks/build');
 
-const obtPath = process.cwd();
+const obtPath = path.resolve(__dirname, '../../');
 const oTestPath = 'test/fixtures/o-test';
 
 const CORE_JS_IDENTIFIER = '__core-js_shared__';


### PR DESCRIPTION
This is no use to the origami build service which requires the JS
and passes path options.

This a chunky commit which aught to be a few:
- Remove build fallback paths which are no longer used due to an
error earlier in the code.
- Require the `cwd` option is set for the demo command (as the build
service already does).
- Remove `process.cwd` fallbacks from file helpers.
- Update tests to remove `process.cwd`.