### PR TITLE
Remove the `disabled` `buildFolder` option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ const buildStream = obt.build.js(gulp, config);
 JavaScript `config` accepts:
 - js: `String` Path to your main JavaScript file. (Default: './main.js' and checks your bower.json to see if it's in its main key)
 - buildJs: `String` Name of the built JavaScript bundle. (Default: 'main.js')
-- buildFolder: `String` Path to directory where the built file will be created. If set to `'disabled'`, files won't be saved. (Default: './build/')
+- buildFolder: `String` Path to directory where the built file will be created. (Default: './build/')
 - env: `String` It can be either 'production' or 'development'. If it's 'production', it will run [uglify](https://github.com/mishoo/UglifyJS2). If it's 'development', it will generate a sourcemap. (Default: 'development')
 - cwd: `String` The path to the working directory, in which the code to be built exists. (Default: current working directory)
 - sourcemaps: `Boolean | 'inline'` Set to true to output sourcemaps as a separate file, even if env is 'production'. Set to 'inline' to output sourcemaps inline (Default: false in production, true in development)
@@ -41,7 +41,7 @@ Sass `config` accepts:
 - autoprefixerRemove: `Boolean` Remove unneeded prefixes (Default: true)
 - cwd: `String` The path to the working directory, in which the code to be built exists. (Default: current working directory)
 - buildCss: `String` Name of the built CSS bundle. (Default: 'main.css')
-- buildFolder: `String` Path to directory where the built file will be created. If set to `'disabled'`, files won't be saved. (Default: './build/')
+- buildFolder: `String` Path to directory where the built file will be created. (Default: './build/')
 - sourcemaps: `Boolean | 'inline'` Set to true to output sourcemaps as a separate file, even if env is 'production'. Set to 'inline' to output sourcemaps inline (Default: false in production, true in development)
 - env: `String` It can be either 'production' or 'development'. If it's 'production', it will compile the Sass file with the 'compressed' style option and will also run [clean-css](https://github.com/jakubpawlowicz/clean-css). (Default: 'development')
 

--- a/lib/tasks/build.js
+++ b/lib/tasks/build.js
@@ -162,9 +162,7 @@ module.exports.js = function(gulp, config) {
 	const combinedStream = combine.obj(
 		gulp.src(src),
 		webpackStream(webpackConfig, webpack),
-		gulpif(destFolder !== 'disabled', function() {
-			return gulp.dest(destFolder);
-		})
+		gulp.dest(destFolder)
 	);
 
 	// Returns a combined stream so an error handler can be attached to the end of the pipeline,
@@ -241,9 +239,7 @@ module.exports.sass = function(gulp, config) {
 			}
 			path.basename = dest;
 		}),
-		gulpif(destFolder !== 'disabled', function() {
-			return gulp.dest(destFolder);
-		})
+		gulp.dest(destFolder)
 	);
 
 	// Returns a combined stream so an error handler can be attached to the end of the pipeline,


### PR DESCRIPTION
The origami build service does not use this