### PR TITLE
Add line to top of readme to mention this repo is no longer being maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+*This project has been merged into the [Origami Build Service](https://github.com/Financial-Times/origami-build-service/pull/324), this repo is no longer maintained.*
+
 # obtv5fork
 
 `obtv5fork` will be used to bundle Origami components within v2 of the [Origami Build Service](https://github.com/Financial-Times/origami-build-service). It is a fork of [origami-build-tools v5](https://github.com/Financial-Times/origami-build-tools), which the [Origami Build Service](https://github.com/Financial-Times/origami-build-service) currently uses, with features for local component development removed.


### PR DESCRIPTION
We no longer maintain this repo because we have moved it's code directly into the origami build service project instead.